### PR TITLE
Update Parallel::Prefork

### DIFF
--- a/META.json
+++ b/META.json
@@ -44,7 +44,7 @@
       "runtime" : {
          "requires" : {
             "Guard" : "0",
-            "Parallel::Prefork" : "0.17",
+            "Parallel::Prefork" : "0.18",
             "Plack" : "1.0037",
             "Server::Starter" : "0",
             "Stream::Buffered" : "0",

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ requires 'perl', '5.008001';
 
 requires 'Plack','1.0037';
 requires 'Stream::Buffered';
-requires 'Parallel::Prefork', '0.17';
+requires 'Parallel::Prefork', '0.18';
 requires 'Server::Starter';
 requires 'Try::Tiny';
 requires 'Guard';


### PR DESCRIPTION
Parallel::Prefork 0.18 is released.
Fixed the broken $pm->wait_all_children without timeout.

So this module should depend on new Parallel::Prefork.
