### PR TITLE
Set $0 to more easily find gazelle in ps(1)

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Gazelle
 
 {{$NEXT}}
 
+ - Set $0 to more easily find gazelle in ps(1) (Arthur Axel fREW Schmidt)
+
 0.46 2016-07-05T06:41:37Z
 
  - do not shutdown if server_starter was used (Thank you zhanghjster)

--- a/lib/Plack/Handler/Gazelle.pm
+++ b/lib/Plack/Handler/Gazelle.pm
@@ -107,6 +107,9 @@ sub setup_listener {
 
 sub run {
     my($self, $app) = @_;
+
+    $0 = 'gazelle master';
+
     $self->setup_listener();
     # use Parallel::Prefork
     my %pm_args = (
@@ -134,6 +137,8 @@ sub run {
     };
     while ($pm->signal_received !~ /^(TERM|USR1)$/) {
         $pm->start(sub{
+            $0 = 'gazelle worker';
+
             srand((rand() * 2 ** 30) ^ $$ ^ time);
 
             my $max_reqs_per_child = $self->_calc_minmax_per_child(


### PR DESCRIPTION
In starman $0 is set to `starman master` and `starman worker` respectively.  This is super handy when doing debugging.  This patch adds the same feature to Gazelle.