### PR TITLE
Pass listen => 1 to Plack::Test::test_psgi

### DIFF
--- a/t/TestUtils.pm
+++ b/t/TestUtils.pm
@@ -13,7 +13,10 @@ sub test_psgi {
     my $pid = fork;
     die $! unless defined $pid;
     if ( $pid == 0 ) {
-      Plack::Test::test_psgi(@_);
+      if (ref $_[0] && @_ == 2) {
+         @_ = (app => $_[0], client => $_[1]);
+      }
+      Plack::Test::test_psgi(listen => 1, @_);
       exit;
     }
     wait;


### PR DESCRIPTION
This gets passed on to Test::TCP which asks the kernel for a free
listening socket, avoiding the race conditions inherent in trying to
find a free one manually.

No need to bump the Plack::Test version dependency, since older versions
will just ignore the parameter and keep working in the racy fashion.